### PR TITLE
Add BotPathVariable default value

### DIFF
--- a/src/main/java/com/github/kshashov/telegram/api/bind/annotation/BotPathVariable.java
+++ b/src/main/java/com/github/kshashov/telegram/api/bind/annotation/BotPathVariable.java
@@ -19,7 +19,7 @@ import java.lang.annotation.*;
 public @interface BotPathVariable {
 
     /**
-     * @return Name of the template variable that should be bound to a method parameter.
+     * @return Name of the template variable that should be bound to a method parameter. If no name is set, variable name will be used instead
      */
     String value() default "";
 }

--- a/src/main/java/com/github/kshashov/telegram/handler/processor/arguments/BotRequestMethodPathArgumentResolver.java
+++ b/src/main/java/com/github/kshashov/telegram/handler/processor/arguments/BotRequestMethodPathArgumentResolver.java
@@ -37,7 +37,13 @@ public class BotRequestMethodPathArgumentResolver implements BotHandlerMethodArg
             return null;
         }
 
-        String value = telegramRequest.getTemplateVariables().get(annotation.value());
+        String value;
+        if (annotation.value().isEmpty()) {
+            value = telegramRequest.getTemplateVariables().get(parameter.getParameterName());
+        } else {
+            value = telegramRequest.getTemplateVariables().get(annotation.value());
+        }
+
         if (value == null) {
             return null;
         }

--- a/src/test/java/com/github/kshashov/telegram/handler/processor/arguments/BotRequestMethodPathArgumentResolverTest.java
+++ b/src/test/java/com/github/kshashov/telegram/handler/processor/arguments/BotRequestMethodPathArgumentResolverTest.java
@@ -7,6 +7,7 @@ import com.github.kshashov.telegram.api.bind.annotation.BotPathVariable;
 import com.pengrad.telegrambot.request.BaseRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.DefaultParameterNameDiscoverer;
 import org.springframework.core.MethodParameter;
 
 import java.math.BigDecimal;
@@ -25,18 +26,24 @@ public class BotRequestMethodPathArgumentResolverTest {
     private TelegramRequest telegramRequest;
     private HashMap<String, String> variables = new HashMap<>();
     private TelegramSession telegramSession;
+    private DefaultParameterNameDiscoverer parameterNameDiscoverer = new DefaultParameterNameDiscoverer();
+
 
     @BeforeEach
     void prepare() {
         this.processor = new BotRequestMethodPathArgumentResolver();
         this.values = Stream.of(TestUtils.findMethodByTitle(this, "method").getParameters())
-                .map(MethodParameter::forParameter)
+                .map(parameter -> {
+                    MethodParameter p = MethodParameter.forParameter(parameter);
+                    p.initParameterNameDiscovery(parameterNameDiscoverer);
+                    return p;
+                })
                 .toArray(MethodParameter[]::new);
 
         this.telegramSession = mock(TelegramSession.class);
         this.telegramRequest = mock(TelegramRequest.class);
         this.variables = new HashMap<>();
-        variables.put("", "empty");
+        variables.put("empty", "emptyText");
         variables.put("text", "text");
         variables.put("int", "12");
         variables.put("double", "12.12");
@@ -88,7 +95,7 @@ public class BotRequestMethodPathArgumentResolverTest {
 
     @Test
     void resolveArgument_DefaultName_ReturnForEmptyString() {
-        assertEquals("empty", processor.resolveArgument(values[4], telegramRequest, telegramSession));
+        assertEquals("emptyText", processor.resolveArgument(values[4], telegramRequest, telegramSession));
     }
 
     @Test
@@ -107,7 +114,7 @@ public class BotRequestMethodPathArgumentResolverTest {
             @BotPathVariable("missed") String missed,
             @BotPathVariable("int") int primitive,
 
-            @BotPathVariable() String empty,
+            @BotPathVariable String empty,
             @BotPathVariable("text") String text,
             @BotPathVariable("text") Integer incorrectInt,
             @BotPathVariable("int") Integer integer,


### PR DESCRIPTION
I think it would be handy if `BotPathVariable ` annotation could works as spring `org.springframework.web.bind.annotation.PathVariable` allowing to leave annotation argument empty