### PR TITLE
Autoconfiguration migration from spring.factories to imports

### DIFF
--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,0 @@
-# Auto Configure
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.github.kshashov.telegram.TelegramAutoConfiguration

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.github.kshashov.telegram.TelegramAutoConfiguration


### PR DESCRIPTION
Fixes #26. In Spring-boot 3 support for ```spring.factories``` was removed. I moved autoconfiguration to 
```META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports```
This change allows [spring-boot-starter-telegram](https://github.com/kshashov/spring-boot-starter-telegram) to work in projects which are using spring-boot 3